### PR TITLE
Update user email and draft counts

### DIFF
--- a/frontend/src/pages/SendEmail.jsx
+++ b/frontend/src/pages/SendEmail.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { templatesAPI, uploadAPI } from '../services/api';
+import { templatesAPI, uploadAPI, authAPI } from '../services/api';
 import toast from 'react-hot-toast';
 import { 
   Send, 
@@ -29,11 +29,16 @@ const SendEmail = () => {
     const handleWindowFocus = () => {
       loadStats();
     };
+    const handleStatsUpdate = () => {
+      loadStats();
+    };
     
     window.addEventListener('focus', handleWindowFocus);
+    window.addEventListener('statsUpdate', handleStatsUpdate);
     
     return () => {
       window.removeEventListener('focus', handleWindowFocus);
+      window.removeEventListener('statsUpdate', handleStatsUpdate);
     };
   }, []);
 
@@ -44,6 +49,8 @@ const SendEmail = () => {
       // Load individual counts
       let templateCount = 0;
       let attachmentCount = 0;
+      let emailsSent = 0;
+      let draftsCreated = 0;
       
       try {
         const templatesResponse = await templatesAPI.getAll();
@@ -61,11 +68,20 @@ const SendEmail = () => {
         console.error('Failed to load attachments:', error);
       }
       
+      try {
+        const profileResponse = await authAPI.getProfile();
+        const profileData = profileResponse.data?.data || profileResponse.data;
+        emailsSent = profileData?.emailsSent || 0;
+        draftsCreated = profileData?.draftsCreated || 0;
+      } catch (error) {
+        console.error('Failed to load profile stats:', error);
+      }
+      
       setStats({
         templates: templateCount,
         attachments: attachmentCount,
-        emailsSent: 0,
-        drafts: 0
+        emailsSent: emailsSent,
+        drafts: draftsCreated
       });
       
     } catch (error) {


### PR DESCRIPTION
Fetch user email and draft counts from the profile to correctly display dashboard statistics.

The dashboard previously displayed 0 for emails sent and drafts created, even when the backend database contained actual counts for the user. This change retrieves these values from the user's profile endpoint and updates the dashboard accordingly, ensuring consistency. It also adds an event listener to refresh these stats when a `statsUpdate` event is dispatched.

---
<a href="https://cursor.com/background-agent?bcId=bc-8adbc2c8-aef8-44c8-a29e-92c29c1214a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8adbc2c8-aef8-44c8-a29e-92c29c1214a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

