### PR TITLE
Fix dashboard template and attachment counts

### DIFF
--- a/frontend/src/pages/Attachments.jsx
+++ b/frontend/src/pages/Attachments.jsx
@@ -108,6 +108,8 @@ const Attachments = () => {
       
       setEditingDescription(null);
       toast.success('Description updated successfully!');
+      // Refresh dashboard stats when attachment is updated
+      refreshDashboardStats();
     } catch (error) {
       console.error('Failed to update description:', error);
       toast.error('Failed to update description');

--- a/frontend/src/pages/SendEmail.jsx
+++ b/frontend/src/pages/SendEmail.jsx
@@ -36,9 +36,17 @@ const SendEmail = () => {
     window.addEventListener('focus', handleWindowFocus);
     window.addEventListener('statsUpdate', handleStatsUpdate);
     
+    // Also refresh stats periodically when dashboard is visible
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        loadStats();
+      }
+    }, 10000); // Refresh every 10 seconds when visible
+    
     return () => {
       window.removeEventListener('focus', handleWindowFocus);
       window.removeEventListener('statsUpdate', handleStatsUpdate);
+      clearInterval(interval);
     };
   }, []);
 
@@ -54,7 +62,7 @@ const SendEmail = () => {
       
       try {
         const templatesResponse = await templatesAPI.getAll();
-        const templatesData = Array.isArray(templatesResponse.data) ? templatesResponse.data : templatesResponse.data?.templates || [];
+        const templatesData = templatesResponse.data?.data?.templates || templatesResponse.data?.templates || [];
         templateCount = templatesData.length;
       } catch (error) {
         console.error('Failed to load templates:', error);
@@ -62,7 +70,7 @@ const SendEmail = () => {
       
       try {
         const attachmentsResponse = await uploadAPI.getAll();
-        const attachmentsData = Array.isArray(attachmentsResponse.data) ? attachmentsResponse.data : attachmentsResponse.data?.attachments || [];
+        const attachmentsData = attachmentsResponse.data?.data?.attachments || attachmentsResponse.data?.attachments || [];
         attachmentCount = attachmentsData.length;
       } catch (error) {
         console.error('Failed to load attachments:', error);

--- a/frontend/src/pages/Templates.jsx
+++ b/frontend/src/pages/Templates.jsx
@@ -124,6 +124,8 @@ const Templates = () => {
       if (editingTemplate) {
         await templatesAPI.update(editingTemplate.id, templateData);
         toast.success('Template updated successfully!');
+        // Refresh dashboard stats when template is updated
+        refreshDashboardStats();
       } else {
         await templatesAPI.create(templateData);
         toast.success('Template created successfully!');

--- a/frontend/src/utils/statsUtils.js
+++ b/frontend/src/utils/statsUtils.js
@@ -1,7 +1,10 @@
 // Utility function to trigger dashboard stats refresh
 export const refreshDashboardStats = () => {
-  // Dispatch custom event to notify dashboard to refresh stats
-  window.dispatchEvent(new CustomEvent('statsUpdate'));
+  // Add a small delay to ensure backend operations are completed
+  setTimeout(() => {
+    // Dispatch custom event to notify dashboard to refresh stats
+    window.dispatchEvent(new CustomEvent('statsUpdate'));
+  }, 100);
 };
 
 export default { refreshDashboardStats };


### PR DESCRIPTION
Fix dashboard template and attachment counts not updating by adding refresh calls, improving data parsing, and implementing periodic refresh.

The dashboard counts were not updating because `refreshDashboardStats()` was not called after update operations for templates and attachments, and the API response structure was incorrectly parsed. A small delay was added to the refresh utility to ensure backend operations complete, and a periodic refresh was introduced for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-215e8626-3d07-488a-9b11-632d5a21a763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-215e8626-3d07-488a-9b11-632d5a21a763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

