### PR TITLE
Debug mass email draft saving error

### DIFF
--- a/frontend/src/pages/MassEmail.jsx
+++ b/frontend/src/pages/MassEmail.jsx
@@ -164,7 +164,13 @@ const MassEmail = () => {
         // Show detailed results - backend returns successCount/failureCount, not summary
         const result = response.data.data || response.data;
         if (result.failureCount > 0) {
-          toast.warn(`${result.successCount} drafts created, ${result.failureCount} failed`);
+          toast(`${result.successCount} drafts created, ${result.failureCount} failed`, {
+            icon: '⚠️',
+            style: {
+              background: '#f59e0b',
+              color: '#ffffff',
+            },
+          });
         }
       }
       


### PR DESCRIPTION
Fix `TypeError: we.warn is not a function` during mass email draft by replacing `toast.warn()` with a custom styled `toast()` call.

---
<a href="https://cursor.com/background-agent?bcId=bc-68b592c4-b5aa-4b0f-88ae-b8fb455a3846">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68b592c4-b5aa-4b0f-88ae-b8fb455a3846">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

